### PR TITLE
Use `ubuntu-latest` instead of manually upgrading

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     check_bindings:
         name: Swift Package Manager Tests
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         env:
             TOOLCHAIN: stable
         steps:
@@ -18,7 +18,7 @@ jobs:
             -   name: Install native Rust toolchain, Valgrind, and build utilities
                 run: |
                     sudo apt-get update
-                    sudo apt-get -y dist-upgrade
+                    sudo apt-get -y upgrade
                     sudo apt-get -y install cargo valgrind lld git g++ clang curl
             -   name: Install Dependencies
                 uses: ./.github/actions/install-dependencies

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -45,28 +45,28 @@ jobs:
                     LDK_SWIFT_GENERATOR_INPUT_HEADER_PATH: ci/ldk-c-bindings/lightning-c-bindings/include/lightning.h
             -   name: Install Swift Toolchain
                 run: |
-                    curl --verbose -L -o swift-5.6-RELEASE-ubuntu20.04.tar.gz https://download.swift.org/swift-5.6-release/ubuntu2004/swift-5.6-RELEASE/swift-5.6-RELEASE-ubuntu20.04.tar.gz
-                    echo "Sha sum: $(sha256sum swift-5.6-RELEASE-ubuntu20.04.tar.gz | awk '{ print $1 }')"
-                    if [ "$(sha256sum swift-5.6-RELEASE-ubuntu20.04.tar.gz | awk '{ print $1 }')" != "${EXPECTED_SWIFT_SHASUM}" ]; then
+                    curl --verbose -L -o swift-5.7.2-RELEASE-ubuntu22.04.tar.gz https://download.swift.org/swift-5.7.2-release/ubuntu2204/swift-5.7.2-RELEASE/swift-5.7.2-RELEASE-ubuntu22.04.tar.gz
+                    echo "Sha sum: $(sha256sum swift-5.7.2-RELEASE-ubuntu22.04.tar.gz | awk '{ print $1 }')"
+                    if [ "$(sha256sum swift-5.7.2-RELEASE-ubuntu22.04.tar.gz | awk '{ print $1 }')" != "${EXPECTED_SWIFT_SHASUM}" ]; then
                       echo "Bad hash"
-                      echo "Contents: \n$(cat swift-5.6-RELEASE-ubuntu20.04.tar.gz)"
+                      echo "Contents: \n$(cat swift-5.7.2-RELEASE-ubuntu22.04.tar.gz)"
                       exit 1
                     fi
-                    tar xvvf swift-5.6-RELEASE-ubuntu20.04.tar.gz
+                    tar xvvf swift-5.7.2-RELEASE-ubuntu22.04.tar.gz
                 env:
-                    EXPECTED_SWIFT_SHASUM: 3f0d926bfc08eea00a69b1d992f2ab5e08155d97476096a3ef959fe7c4cbd58b
+                    EXPECTED_SWIFT_SHASUM: e729912846b0cff98bf8e0e5ede2e17bc2d1098de3cdb6fa13b3ff52c36ee5d6
             -   name: Build Swift bindings package
                 run: |
                     cd ci/LDKSwift
-                    ../../swift-5.6-RELEASE-ubuntu20.04/usr/bin/swift build
+                    ../../swift-5.7.2-RELEASE-ubuntu22.04/usr/bin/swift build
                 env:
                     LDK_C_BINDINGS_BASE: /home/runner/work/ldk-parser/ldk-parser/ci/ldk-c-bindings
-                    LLVM_CLANG_ASAN_PATH: /usr/lib/llvm-11/lib/clang/11.0.0/lib/linux/libclang_rt.asan-x86_64.a
+                    LLVM_CLANG_ASAN_PATH: /usr/lib/llvm-14/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.a
                     RUST_BACKTRACE: 1
             -   name: Test Swift bindings package without address sanitizer
                 run: |
                     cd ci/LDKSwift
-                    ../../swift-5.6-RELEASE-ubuntu20.04/usr/bin/swift test -v
+                    ../../swift-5.7.2-RELEASE-ubuntu22.04/usr/bin/swift test -v
                 env:
                     LDK_C_BINDINGS_BASE: /home/runner/work/ldk-parser/ldk-parser/ci/ldk-c-bindings
                     RUST_BACKTRACE: 1
@@ -74,8 +74,8 @@ jobs:
                 continue-on-error: true
                 run: |
                     cd ci/LDKSwift
-                    ../../swift-5.6-RELEASE-ubuntu20.04/usr/bin/swift test -v
+                    ../../swift-5.7.2-RELEASE-ubuntu22.04/usr/bin/swift test -v
                 env:
                     LDK_C_BINDINGS_BASE: /home/runner/work/ldk-parser/ldk-parser/ci/ldk-c-bindings
-                    LLVM_CLANG_ASAN_PATH: /usr/lib/llvm-11/lib/clang/11.0.0/lib/linux/libclang_rt.asan-x86_64.a
+                    LLVM_CLANG_ASAN_PATH: /usr/lib/llvm-14/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.a
                     RUST_BACKTRACE: 1


### PR DESCRIPTION
Currently the CI setup takes pretty long, as we manually upgrade a lot of packages we don't need (Firefox, etc).

This opts to use `ubuntu-latest` instead of doing the `dist-upgrade` manually. It could be debatable if we need to upgrade packages at all?